### PR TITLE
apply_defaults to bind_partial

### DIFF
--- a/src/stream_ml/visualization/utils/arg_decorators.py
+++ b/src/stream_ml/visualization/utils/arg_decorators.py
@@ -44,6 +44,7 @@ def with_sorter(plotting_func: Callable[P, R]) -> Callable[P, R]:
         # Get the sorter, or create it if it doesn't exist.
         if kwargs.get("sorter") is None:
             ba = sig.bind_partial(*args, **kwargs)
+            ba.apply_defaults()
             data = ba.arguments["data"]
             sorter = np.argsort(data["phi1"].flatten())
             kwargs["sorter"] = sorter
@@ -87,6 +88,7 @@ def make_tuple(*arg_names: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
         def make_tuple_inner_inner(*args: P.args, **kwargs: P.kwargs) -> R:
             # Get the argument, or create it if it doesn't exist.
             ba = sig.bind_partial(*args, **kwargs)
+            ba.apply_defaults()
             for arg_name in arg_names:
                 arg = ba.arguments[arg_name]
                 ba.arguments[arg_name] = (arg,) if not isinstance(arg, tuple) else arg


### PR DESCRIPTION
bind-partial misses non-specified arguments, which are necessary for args with defaults.


## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
